### PR TITLE
feat(geosuggest): add optional `placeDetailsField` prop to limit place details fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Our communications here on GitHub follow certain guidelines. Please observe the 
 
 ## Pull Requests / Merge Requests
 
-- **IMPORTANT**: by submitting a patch, you agree to allow the project owners to license your work under this [LICENSE](LICENSE)
+- **IMPORTANT**: by submitting a patch, you agree to allow the project owners to license your work under this [LICENSE.md](LICENSE.md)
 
 - please provide test cases for all features and bug fixes
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Default: `10`
 
 Maximum number of fixtures to render.
 
+#### placeDetailFields
+Type: `Array`
+Default: `null`
+
+By default Google returns all fields when getting place details which can [impact billing](https://developers.google.com/maps/billing/understanding-cost-of-use#data-skus). You can optionally pass an [array of fields to include in place results](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceDetailsRequest.fields) to limit what is returned and potentially reduce billing impact.
+
 #### googleMaps
 Type: `Object`
 Default: `google.maps`

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -487,10 +487,14 @@ export default class extends React.Component<IProps, IState> {
     }
 
     if (suggestToGeocode.placeId && !suggestToGeocode.isFixture && this.placesService) {
-      const options = {
+      const options: any = {
         placeId: suggestToGeocode.placeId,
         sessionToken: this.sessionToken
       };
+
+      if (this.props.placeDetailFields) {
+        options.fields = this.props.placeDetailFields;
+      }
 
       this.placesService.getDetails(options, (results, status) => {
         if (status === this.googleMaps.places.PlacesServiceStatus.OK) {

--- a/src/types/props.d.ts
+++ b/src/types/props.d.ts
@@ -48,4 +48,5 @@ export default interface IProps {
   readonly label?: string;
   readonly autoComplete?: string;
   readonly minLength?: number;
+  readonly placeDetailFields?: string[] | null;
 }


### PR DESCRIPTION
### Description
By default Google returns all fields in Place Results which can impact billing (Atmosphere Data and Contact Data cost extra for each request and are included by default). This allows specifying a limited set of fields to return which can help reduce billing by only requesting needed data (eg. only [Basic Data](https://developers.google.com/maps/billing/understanding-cost-of-use#basic-data)).

### Checklist
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
